### PR TITLE
fix(sec): rate limit outbound SEC API fetches

### DIFF
--- a/server/src/common/Data.service.spec.ts
+++ b/server/src/common/Data.service.spec.ts
@@ -1,0 +1,56 @@
+import axios from 'axios';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { findUnique } from './Data.service';
+
+jest.mock('axios');
+jest.mock('fs/promises');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedReadFile = readFile as jest.MockedFunction<typeof readFile>;
+const mockedWriteFile = writeFile as jest.MockedFunction<typeof writeFile>;
+const mockedMkdir = mkdir as jest.MockedFunction<typeof mkdir>;
+
+describe('findUnique', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedReadFile.mockRejectedValue(new Error('ENOENT'));
+    mockedWriteFile.mockResolvedValue(undefined);
+    mockedMkdir.mockResolvedValue(undefined);
+    mockedAxios.get.mockImplementation(() =>
+      Promise.resolve({ data: { ok: true } }),
+    );
+  });
+
+  it('spaces out concurrent SEC API requests to respect the rate limit', async () => {
+    const callTimestamps: number[] = [];
+    mockedAxios.get.mockImplementation(() => {
+      callTimestamps.push(Date.now());
+      return Promise.resolve({ data: { ok: true } });
+    });
+
+    await Promise.all([
+      findUnique('companyfacts', '0000000001'),
+      findUnique('companyfacts', '0000000002'),
+      findUnique('companyfacts', '0000000003'),
+    ]);
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+    expect(callTimestamps).toHaveLength(3);
+    for (let i = 1; i < callTimestamps.length; i++) {
+      expect(callTimestamps[i] - callTimestamps[i - 1]).toBeGreaterThanOrEqual(
+        140,
+      );
+    }
+  });
+
+  it('still returns fetched data and caches it to disk', async () => {
+    const data = await findUnique('submissions', '0000000042');
+
+    expect(data).toEqual({ ok: true });
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('CIK0000000042.json'),
+      JSON.stringify({ ok: true }, null, 2),
+      'utf-8',
+    );
+  });
+});

--- a/server/src/common/Data.service.ts
+++ b/server/src/common/Data.service.ts
@@ -3,6 +3,33 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { RequestType } from 'src/types';
 
+// SEC's fair access policy caps automated traffic at 10 requests/second
+// (https://www.sec.gov/os/webmaster-faq#developers). Stay comfortably under
+// that by serializing outbound fetches with a minimum gap between them.
+const SEC_MIN_REQUEST_INTERVAL_MS = 150;
+let secRequestQueue: Promise<void> = Promise.resolve();
+
+async function rateLimitedFetch(secUrl: string) {
+  let release: () => void;
+  const wait = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  const previous = secRequestQueue;
+  secRequestQueue = secRequestQueue.then(() => wait);
+
+  await previous;
+  try {
+    return await axios.get(secUrl, {
+      headers: {
+        'User-Agent': 'MyExpressApp/1.0',
+      },
+    });
+  } finally {
+    setTimeout(() => release(), SEC_MIN_REQUEST_INTERVAL_MS);
+  }
+}
+
 export async function findUnique(dataType: RequestType, cik: string) {
   const fileName = `CIK${cik}.json`;
   const filePath = join(__dirname, '..', '..', 'data', dataType, fileName);
@@ -17,11 +44,7 @@ export async function findUnique(dataType: RequestType, cik: string) {
     const secUrl = `https://data.sec.gov/api/${dataType}/${fileName}`;
 
     try {
-      const response = await axios.get(secUrl, {
-        headers: {
-          'User-Agent': 'MyExpressApp/1.0',
-        },
-      });
+      const response = await rateLimitedFetch(secUrl);
       const data = response.data;
       await mkdir(dirname(filePath), { recursive: true });
       await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');


### PR DESCRIPTION
## Summary
- `Data.service.ts` fetched missing CIK data from `data.sec.gov` with no throttling — a burst of cache-miss requests (e.g. many CIKs requested around the same time) could send requests faster than SEC's fair access policy allows.
- Serializes outbound SEC API calls through a small queue that enforces a minimum gap between requests, keeping the service well under SEC's rate limit regardless of how many concurrent lookups miss the local cache.
- Cached reads (the common case) are unaffected — the limiter only applies to the fallback fetch-from-SEC path.

Closes #2

## Test plan
- [x] `pnpm test` — added a spec covering concurrent fetches (asserts requests are spaced out) and the existing fetch/cache-to-disk behavior
- [x] `pnpm lint`
- [x] `pnpm build`

---
This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim.