### PR TITLE
Add block-no-verify hook to block --no-verify bypass

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__github__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Wires up [`block-no-verify`](https://www.npmjs.com/package/block-no-verify) as a Claude Code `PreToolUse` hook in `.claude/settings.json`.
- Blocks the `--no-verify` flag / `core.hooksPath` overrides on `git commit`, `push`, `merge`, `cherry-pick`, `rebase`, `am`.
- Also blocks direct-to-API GitHub MCP tools (`mcp__github__.*`) that would otherwise skip local git hooks.
- Config matches the package README's documented Claude Code integration.

This pull request was opened by the "Add block-no-verify hook to a repo" routine of moadim. cc @tupe12334

## Test plan
- [ ] Verify `.claude/settings.json` is picked up by Claude Code in this repo
- [ ] Confirm `git commit --no-verify` is blocked when using Claude Code here