### PR TITLE
Download zip files on service boot

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "nestjs-zod": "^4.3.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
+    "unzipper": "^0.12.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {
@@ -39,6 +40,7 @@
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
     "@types/supertest": "^6.0.0",
+    "@types/unzipper": "^0.10.11",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.42.0",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
+      unzipper:
+        specifier: ^0.12.5
+        version: 0.12.5
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -63,6 +66,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.2
+      '@types/unzipper':
+        specifier: ^0.10.11
+        version: 0.10.11
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.0.0
         version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
@@ -724,6 +730,9 @@ packages:
   '@types/supertest@6.0.2':
     resolution: {integrity: sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==}
 
+  '@types/unzipper@0.10.11':
+    resolution: {integrity: sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -1015,6 +1024,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -1339,6 +1351,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1631,6 +1646,10 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
+
+  fs-extra@11.3.1:
+    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
+    engines: {node: '>=14.14'}
 
   fs-monkey@1.0.6:
     resolution: {integrity: sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==}
@@ -3052,6 +3071,9 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unzipper@0.12.5:
+    resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
+
   update-browserslist-db@1.1.2:
     resolution: {integrity: sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==}
     hasBin: true
@@ -3070,6 +3092,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -3982,6 +4005,10 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
 
+  '@types/unzipper@0.10.11':
+    dependencies:
+      '@types/node': 20.17.19
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@17.0.33':
@@ -4346,6 +4373,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bluebird@3.7.2: {}
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -4661,6 +4690,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
 
   eastasianwidth@0.2.0: {}
 
@@ -5035,6 +5068,12 @@ snapshots:
   fresh@0.5.2: {}
 
   fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.1:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -6544,6 +6583,14 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unzipper@0.12.5:
+    dependencies:
+      bluebird: 3.7.2
+      duplexer2: 0.1.4
+      fs-extra: 11.3.1
+      graceful-fs: 4.2.11
+      node-int64: 0.4.0
 
   update-browserslist-db@1.1.2(browserslist@4.24.4):
     dependencies:

--- a/server/src/common/BulkData.service.spec.ts
+++ b/server/src/common/BulkData.service.spec.ts
@@ -1,0 +1,71 @@
+import axios from 'axios';
+import { EventEmitter } from 'events';
+import { createWriteStream } from 'fs';
+import { mkdir, readdir, rm } from 'fs/promises';
+import { Open } from 'unzipper';
+import { downloadBulkDataOnBoot } from './BulkData.service';
+
+jest.mock('axios');
+jest.mock('fs');
+jest.mock('fs/promises');
+jest.mock('unzipper');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedReaddir = readdir as jest.MockedFunction<typeof readdir>;
+const mockedMkdir = mkdir as jest.MockedFunction<typeof mkdir>;
+const mockedRm = rm as jest.MockedFunction<typeof rm>;
+const mockedCreateWriteStream = createWriteStream as jest.MockedFunction<
+  typeof createWriteStream
+>;
+const mockedOpen = Open as jest.Mocked<typeof Open>;
+
+function fakeWriter() {
+  const writer = new EventEmitter() as any;
+  process.nextTick(() => writer.emit('finish'));
+  return writer;
+}
+
+describe('downloadBulkDataOnBoot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedMkdir.mockResolvedValue(undefined);
+    mockedRm.mockResolvedValue(undefined);
+    mockedCreateWriteStream.mockImplementation(() => fakeWriter());
+    mockedAxios.get.mockResolvedValue({ data: { pipe: jest.fn() } });
+    mockedOpen.file.mockResolvedValue({
+      extract: jest.fn().mockResolvedValue(undefined),
+    } as any);
+  });
+
+  it('skips downloading a dataset whose data dir is already populated', async () => {
+    mockedReaddir.mockResolvedValue(['CIK0000000001.json'] as any);
+
+    await downloadBulkDataOnBoot();
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(mockedOpen.file).not.toHaveBeenCalled();
+  });
+
+  it('downloads and extracts a dataset whose data dir is empty', async () => {
+    mockedReaddir.mockResolvedValue([] as any);
+
+    await downloadBulkDataOnBoot();
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining('.zip'),
+      expect.objectContaining({ responseType: 'stream' }),
+    );
+    expect(mockedOpen.file).toHaveBeenCalled();
+    expect(mockedRm).toHaveBeenCalled();
+  });
+
+  it('keeps going for the next dataset if one dataset fails', async () => {
+    mockedReaddir.mockResolvedValue([] as any);
+    mockedAxios.get.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(downloadBulkDataOnBoot()).resolves.toBeUndefined();
+
+    // still attempted both datasets despite the first failing
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/common/BulkData.service.ts
+++ b/server/src/common/BulkData.service.ts
@@ -1,0 +1,80 @@
+import axios from 'axios';
+import { createWriteStream } from 'fs';
+import { mkdir, readdir, rm } from 'fs/promises';
+import { join } from 'path';
+import { Open } from 'unzipper';
+import { RequestType } from 'src/types';
+
+// SEC publishes the entire submissions/companyfacts datasets as bulk zips
+// (each file inside is named `CIK##########.json`, same as the per-CIK
+// fetch in Data.service.ts). Downloading + extracting them into the same
+// `data/<dataType>` directory on boot seeds the local cache so lookups are
+// served from disk instead of hitting data.sec.gov one CIK at a time.
+const BULK_DATA_URLS: Record<RequestType, string> = {
+  submissions:
+    'https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip',
+  companyfacts:
+    'https://www.sec.gov/Archives/edgar/daily-index/xbrl/companyfacts.zip',
+};
+
+async function isEmptyDir(dir: string): Promise<boolean> {
+  try {
+    const entries = await readdir(dir);
+    return entries.length === 0;
+  } catch {
+    return true; // doesn't exist yet
+  }
+}
+
+async function downloadAndExtract(dataType: RequestType): Promise<void> {
+  const destDir = join(__dirname, '..', '..', 'data', dataType);
+
+  // ponytail: these zips are ~1.5GB each, so only fetch them when the data
+  // dir is empty rather than on every boot. Clear the dir to force a refresh.
+  if (!(await isEmptyDir(destDir))) {
+    console.log(`Bulk ${dataType} data already present, skipping download`);
+    return;
+  }
+
+  await mkdir(destDir, { recursive: true });
+  const url = BULK_DATA_URLS[dataType];
+  const tmpZipPath = join(destDir, '..', `${dataType}.zip.tmp`);
+
+  console.log(`Downloading bulk ${dataType} data from ${url}...`);
+  const response = await axios.get(url, {
+    responseType: 'stream',
+    headers: { 'User-Agent': 'MyExpressApp/1.0' },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const writer = createWriteStream(tmpZipPath);
+    response.data.pipe(writer);
+    writer.on('finish', () => resolve());
+    writer.on('error', reject);
+  });
+
+  try {
+    console.log(`Extracting bulk ${dataType} data into ${destDir}...`);
+    const directory = await Open.file(tmpZipPath);
+    await directory.extract({ path: destDir, concurrency: 5 });
+    console.log(`Bulk ${dataType} data ready`);
+  } finally {
+    await rm(tmpZipPath, { force: true });
+  }
+}
+
+/**
+ * Seeds the local cache from SEC's bulk data zips. Runs in the background
+ * (fire-and-forget from main.ts) so a multi-GB download doesn't delay the
+ * server from listening/answering healthchecks; per-CIK requests still fall
+ * back to the live SEC API (see Data.service.ts) while this is in flight.
+ */
+export async function downloadBulkDataOnBoot(): Promise<void> {
+  for (const dataType of Object.keys(BULK_DATA_URLS) as RequestType[]) {
+    try {
+      await downloadAndExtract(dataType);
+    } catch (err) {
+      console.error(`Failed to download bulk ${dataType} data:`, err);
+    }
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -5,6 +5,7 @@ import { writeFile } from 'fs/promises';
 import { patchNestJsSwagger } from 'nestjs-zod';
 import { join } from 'path';
 import { AppModule } from './app.module';
+import { downloadBulkDataOnBoot } from './common/BulkData.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -27,5 +28,11 @@ async function bootstrap() {
 
   SwaggerModule.setup('api', app, document);
   await app.listen(3000);
+
+  // Seed the local cache from SEC's bulk data zips in the background so the
+  // (multi-GB) download doesn't delay the server from listening.
+  downloadBulkDataOnBoot().catch((err) =>
+    Logger.error('Bulk data download failed', err, 'BulkData'),
+  );
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- Issue #1 asked for the service to download "the zip files" on boot. The repo's README says to manually mount a volume with the companyfacts/submissions data, and the per-CIK cache in `Data.service.ts` writes files as `CIK<cik>.json` under `data/<companyfacts|submissions>/`. An earlier commit (`6cc98f9`) had already added `@nestjs/schedule` and cspell entries for `bulkdata`/`xbrl` in anticipation of this — matching SEC's actual bulk dataset URLs, which I verified resolve:
  - `https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip`
  - `https://www.sec.gov/Archives/edgar/daily-index/xbrl/companyfacts.zip`
- Added `server/src/common/BulkData.service.ts`, which downloads and streams-extracts both zips into the same `data/<dataType>/` directories the existing per-CIK cache reads from (each zip entry is already named `CIK##########.json`, so no reshaping is needed).
- Wired it into `main.ts` as a fire-and-forget call *after* `app.listen`, so the multi-GB download doesn't delay the server from listening/answering requests. If a dataset's data dir already has files, that dataset's download is skipped (avoids re-pulling ~1.5GB zips on every restart); per-dataset errors are caught/logged so one failing dataset doesn't block the other or crash boot.
- Individual CIK lookups still work as before via the existing on-demand fetch-from-SEC fallback while the bulk seed is in flight.

Closes #1

## Test plan
- [x] `pnpm test` — new `BulkData.service.spec.ts` covers: skip-when-populated, download+extract-when-empty, and continuing to the next dataset after one fails
- [x] `pnpm lint`
- [x] `pnpm build`

---
This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim.