### PR TITLE
fix(server): replace custom SEC rate-limiter queue with Bottleneck

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "@nestjs/schedule": "^5.0.1",
     "@nestjs/swagger": "^11.0.4",
     "axios": "^1.7.9",
+    "bottleneck": "^2.19.5",
     "nestjs-paginate": "^11.0.1",
     "nestjs-zod": "^4.3.1",
     "reflect-metadata": "^0.2.0",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       axios:
         specifier: ^1.7.9
         version: 1.7.9
+      bottleneck:
+        specifier: ^2.19.5
+        version: 2.19.5
       nestjs-paginate:
         specifier: ^11.0.1
         version: 11.0.1(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/swagger@11.0.4(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2))(express@4.21.2)(fastify@5.2.1)(typeorm@0.3.20(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.7.3)))
@@ -1714,6 +1717,9 @@ packages:
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -6534,6 +6540,8 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  bottleneck@2.19.5: {}
 
   brace-expansion@1.1.11:
     dependencies:

--- a/server/src/common/Data.service.ts
+++ b/server/src/common/Data.service.ts
@@ -1,33 +1,26 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import axios from 'axios';
+import Bottleneck from 'bottleneck';
 import type { RequestType } from 'src/types';
 
 // SEC's fair access policy caps automated traffic at 10 requests/second
 // (https://www.sec.gov/os/webmaster-faq#developers). Stay comfortably under
 // that by serializing outbound fetches with a minimum gap between them.
 const SEC_MIN_REQUEST_INTERVAL_MS = 150;
-let secRequestQueue: Promise<void> = Promise.resolve();
+const secRequestLimiter = new Bottleneck({
+  maxConcurrent: 1,
+  minTime: SEC_MIN_REQUEST_INTERVAL_MS,
+});
 
 async function rateLimitedFetch(secUrl: string) {
-  let release: () => void;
-  const wait = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-
-  const previous = secRequestQueue;
-  secRequestQueue = secRequestQueue.then(async () => wait);
-
-  await previous;
-  try {
-    return await axios.get(secUrl, {
+  return secRequestLimiter.schedule(async () =>
+    axios.get(secUrl, {
       headers: {
         'User-Agent': 'MyExpressApp/1.0',
       },
-    });
-  } finally {
-    setTimeout(() => { release(); }, SEC_MIN_REQUEST_INTERVAL_MS);
-  }
+    }),
+  );
 }
 
 export async function findUnique(dataType: RequestType, cik: string) {


### PR DESCRIPTION
## Summary
- `server/src/common/Data.service.ts` hand-rolled a promise-chain queue with a manual `setTimeout` release to keep outbound SEC fetches under the 10 req/s fair-access cap.
- Replaced it with [Bottleneck](https://www.npmjs.com/package/bottleneck) (`maxConcurrent: 1`, `minTime: 150`), which expresses the same policy in a few lines and removes the manual concurrency bookkeeping.

Closes #8

## Test plan
- [x] `pnpm test` — existing `Data.service.spec.ts` (including the concurrent-request spacing assertion) passes unchanged
- [x] `pnpm run lint` — 0 errors (pre-existing warnings elsewhere unrelated to this change)
- [x] `pnpm run build` — compiles successfully