### PR TITLE
chore: add missing changeset

### DIFF
--- a/.changeset/fix-server-sec-rate-limit-throttle.md
+++ b/.changeset/fix-server-sec-rate-limit-throttle.md
@@ -1,0 +1,5 @@
+---
+"@stockspro/sec": patch
+---
+
+Throttle outbound SEC API fetches to stay within SEC's fair-access rate limits. (#3)


### PR DESCRIPTION
Adds a pending changeset for a merged PR since the last release that doesn't have one yet.

Covers:
- #3 — throttle outbound SEC API fetches (patch, @stockspro/sec)

Depends on #10 (changesets tooling bootstrap) for `.changeset/config.json`.