### PR TITLE
chore: add missing changeset

### DIFF
--- a/.changeset/replace-rate-limiter-with-bottleneck.md
+++ b/.changeset/replace-rate-limiter-with-bottleneck.md
@@ -1,0 +1,5 @@
+---
+"@stockspro/sec": patch
+---
+
+Replace the hand-rolled promise-chain SEC API rate-limiter queue with the Bottleneck library for throttling outbound requests (#9).


### PR DESCRIPTION
## Summary
- Adds the missing Changesets entry for PR #9 (fix(server): replace custom SEC rate-limiter queue with Bottleneck), merged 2026-07-05.
- Bump: patch for `@stockspro/sec`.

No other files touched.